### PR TITLE
Support A12 & iPhone XR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,14 @@ export ADDITIONAL_CFLAGS = -I$(THEOS_PROJECT_DIR)/../headers
 # export USE_SUBSTRATE=0
 include $(THEOS)/makefiles/common.mk
 
+ARCHS = armv7 arm64 arm64e
+
 TWEAK_NAME = PeekaBoo
-PeekaBoo_CFLAGS = -fobjc-arc -I./headers
+PeekaBoo_CFLAGS = -fobjc-arc -I./headers -std=c++11 -stdlib=libc++
 PeekaBoo_FILES = Tweak.xm
 PeekaBoo_FRAMEWORKS = UIKit AudioToolbox CoreMedia
 PeekaBoo_LIBRARIES = MobileGestalt
-PeekaBoo_LDFLAGS += ./AppSupport.tbd ./IOKit.tbd
+PeekaBoo_LDFLAGS += ./AppSupport.tbd ./IOKit.tbd -stdlib=libc++
 
 include $(THEOS_MAKE_PATH)/tweak.mk
 

--- a/control
+++ b/control
@@ -1,7 +1,7 @@
 Package: com.ioscreatix.peek-a-boo
 Name: Peek-a-Boo
 Depends: mobilesubstrate
-Version: 11.0.2
+Version: 12.0.0
 Architecture: iphoneos-arm
 Description: 3D Touch on Non-3D-Touch Devices
 Maintainer: iOS Creatix

--- a/settings/Makefile
+++ b/settings/Makefile
@@ -7,8 +7,8 @@ BUNDLE_NAME = PeekaBoo
 PeekaBoo_FILES = PABRootListController.m PABAppSettingsController.m OrderedDictionary.m
 PeekaBoo_INSTALL_PATH = /Library/PreferenceBundles
 PeekaBoo_FRAMEWORKS = UIKit
-PeekaBoo_LDFLAGS += ./Preferences.tbd ./SpringBoardServices.tbd
-PeekaBoo_CFLAGS = -fobjc-arc -I./headers
+PeekaBoo_LDFLAGS += ./Preferences.tbd ./SpringBoardServices.tbd -stdlib=libc++
+PeekaBoo_CFLAGS = -fobjc-arc -I./headers -std=c++11 -stdlib=libc++
 
 include $(THEOS_MAKE_PATH)/bundle.mk
 

--- a/settings/Makefile
+++ b/settings/Makefile
@@ -3,6 +3,8 @@ CFLAGS = -fobjc-arc
 ADDITIONAL_OBJCFLAGS = -fobjc-arc
 include $(THEOS)/makefiles/common.mk
 
+ARCHS = armv7 arm64 arm64e
+
 BUNDLE_NAME = PeekaBoo
 PeekaBoo_FILES = PABRootListController.m PABAppSettingsController.m OrderedDictionary.m
 PeekaBoo_INSTALL_PATH = /Library/PreferenceBundles


### PR DESCRIPTION
iPhone XR supports haptic feedback so there is no need to call `%init(Haptics);` (and will lead to crash if calling it)